### PR TITLE
Tarkemmat tyypitystarkistukset

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,11 +8,6 @@ repos:
       - id: end-of-file-fixer
       - id: check-yaml
       - id: check-added-large-files
-  - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.11.2
-    hooks:
-      - id: mypy
-        additional_dependencies: ["types-PyYAML"]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.6.5
     hooks:

--- a/arho_feature_template/__init__.py
+++ b/arho_feature_template/__init__.py
@@ -1,21 +1,32 @@
+from __future__ import annotations
+
 import os
 from typing import TYPE_CHECKING
-
-from arho_feature_template.qgis_plugin_tools.infrastructure.debugging import (
-    setup_debugpy,  # noqa: F401
-    setup_ptvsd,  # noqa: F401
-    setup_pydevd,  # noqa: F401
-)
 
 if TYPE_CHECKING:
     from qgis.gui import QgisInterface
 
-debugger = os.environ.get("QGIS_PLUGIN_USE_DEBUGGER", "").lower()
-if debugger in {"debugpy", "ptvsd", "pydevd"}:
-    locals()["setup_" + debugger]()
+    from arho_feature_template.plugin import Plugin
+
+debugger = os.environ.get("QGIS_PLUGIN_USE_DEBUGGER")
+if debugger is not None:
+    from arho_feature_template.qgis_plugin_tools.infrastructure.debugging import (
+        setup_debugpy,
+        setup_ptvsd,
+        setup_pydevd,
+    )
+
+    debugger_setups = {
+        "debugpy": setup_debugpy,
+        "ptvsd": setup_ptvsd,
+        "pydevd": setup_pydevd,
+    }
+    debug_setupper = debugger_setups.get(debugger.lower())
+    if debug_setupper is not None:
+        debug_setupper()
 
 
-def classFactory(iface: "QgisInterface"):  # noqa N802
+def classFactory(iface: "QgisInterface") -> Plugin:  # noqa N802
     from arho_feature_template.plugin import Plugin
 
     return Plugin()

--- a/arho_feature_template/core/feature_template_library.py
+++ b/arho_feature_template/core/feature_template_library.py
@@ -1,12 +1,12 @@
 from __future__ import annotations
 
 import logging
+from typing import TYPE_CHECKING
 
 from qgis.core import QgsFeature, QgsProject, QgsVectorLayer
 from qgis.gui import QgsMapToolDigitizeFeature
 from qgis.PyQt.QtCore import QItemSelectionModel
 from qgis.PyQt.QtGui import QStandardItem, QStandardItemModel
-from qgis.utils import iface
 
 from arho_feature_template.core.template_library_config import (
     FeatureTemplate,
@@ -18,6 +18,7 @@ from arho_feature_template.core.template_library_config import (
 from arho_feature_template.gui.feature_attribute_form import FeatureAttributeForm
 from arho_feature_template.gui.template_dock import TemplateLibraryDock
 from arho_feature_template.resources.template_libraries import library_config_files
+from arho_feature_template.utils.qgis_utils import iface
 
 logger = logging.getLogger(__name__)
 

--- a/arho_feature_template/core/feature_template_library.py
+++ b/arho_feature_template/core/feature_template_library.py
@@ -1,13 +1,14 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from qgis.core import QgsFeature, QgsProject, QgsVectorLayer
 from qgis.gui import QgsMapToolDigitizeFeature
 from qgis.PyQt.QtCore import QItemSelectionModel
 from qgis.PyQt.QtGui import QStandardItem, QStandardItemModel
 
+from arho_feature_template.core.exceptions import UnexpectedNoneError
 from arho_feature_template.core.template_library_config import (
     FeatureTemplate,
     TemplateLibraryConfig,
@@ -19,6 +20,9 @@ from arho_feature_template.gui.feature_attribute_form import FeatureAttributeFor
 from arho_feature_template.gui.template_dock import TemplateLibraryDock
 from arho_feature_template.resources.template_libraries import library_config_files
 from arho_feature_template.utils.qgis_utils import iface
+
+if TYPE_CHECKING:
+    from qgis.PyQt.QtCore import QModelIndex
 
 logger = logging.getLogger(__name__)
 
@@ -100,8 +104,8 @@ class FeatureTemplater:
         self.digitize_map_tool.digitizingCompleted.connect(self.ask_for_feature_attributes)
         self.digitize_map_tool.deactivated.connect(self.template_dock.template_list.clearSelection)
 
-    def on_template_item_clicked(self, index):
-        item = self.template_model.itemFromIndex(index)
+    def on_template_item_clicked(self, index: QModelIndex) -> None:
+        item = cast(TemplateItem, self.template_model.itemFromIndex(index))
         try:
             layer = get_layer_from_project(item.config.feature.layer)
         except (LayerNotFoundError, LayerNotVectorTypeError):
@@ -115,7 +119,7 @@ class FeatureTemplater:
             index, QItemSelectionModel.Select | QItemSelectionModel.Rows
         )
 
-    def on_template_search_text_changed(self, search_text: str):
+    def on_template_search_text_changed(self, search_text: str) -> None:
         for row in range(self.template_model.rowCount()):
             item = self.template_model.item(row)
 
@@ -134,7 +138,10 @@ class FeatureTemplater:
             if not succeeded:
                 logger.warning("Failed to start editing layer %s", layer.name())
                 return
-        iface.mapCanvas().setMapTool(self.digitize_map_tool)
+        canvas = iface.mapCanvas()
+        if not canvas:
+            raise UnexpectedNoneError
+        canvas.setMapTool(self.digitize_map_tool)
 
     def ask_for_feature_attributes(self, feature: QgsFeature) -> None:
         """Shows a dialog to ask for feature attributes and creates the feature"""
@@ -151,7 +158,7 @@ class FeatureTemplater:
                 for attribute, widget in attributes.items():
                     feature.setAttribute(
                         attribute,
-                        widget.text(),
+                        widget.text(),  # type: ignore
                     )
 
             layer.beginEditCommand("Create feature from template")

--- a/arho_feature_template/core/new_plan.py
+++ b/arho_feature_template/core/new_plan.py
@@ -1,9 +1,7 @@
-from typing import TYPE_CHECKING
-
-from qgis.core import QgsProject, QgsVectorLayer
+from qgis.core import Qgis, QgsProject, QgsVectorLayer
 
 from arho_feature_template.core.update_plan import LandUsePlan, update_selected_plan
-from arho_feature_template.utils.qgis_utils import iface
+from arho_feature_template.utils.qgis_utils import iface, show_message_bar
 
 
 class NewPlan:
@@ -13,7 +11,7 @@ class NewPlan:
 
         layers = QgsProject.instance().mapLayersByName("Kaava")
         if not layers:
-            iface.messageBar().pushMessage("Error", "Layer 'Kaava' not found", level=3)
+            show_message_bar("Error", "Layer 'Kaava' not found", level=Qgis.MessageLevel.Warning)
             return
 
         kaava_layer = layers[0]
@@ -34,10 +32,10 @@ class NewPlan:
         feature_ids_before_commit = kaava_layer.allFeatureIds()
         if kaava_layer.isEditable():
             if not kaava_layer.commitChanges():
-                iface.messageBar().pushMessage("Error", "Failed to commit changes to the layer.", level=3)
+                show_message_bar("Error", "Failed to commit changes to the layer.", level=Qgis.MessageLevel.Warning)
                 return
         else:
-            iface.messageBar().pushMessage("Error", "Layer is not editable.", level=3)
+            show_message_bar("Error", "Layer is not editable.", level=Qgis.MessageLevel.Warning)
             return
 
         feature_ids_after_commit = kaava_layer.allFeatureIds()
@@ -52,9 +50,9 @@ class NewPlan:
                 feature_id_value = new_feature["id"]
                 update_selected_plan(LandUsePlan(feature_id_value))
             else:
-                iface.messageBar().pushMessage("Error", "Invalid feature retrieved.", level=3)
+                show_message_bar("Error", "Invalid feature retrieved.", level=Qgis.MessageLevel.Warning)
         else:
-            iface.messageBar().pushMessage("Error", "No new feature was added.", level=3)
+            show_message_bar("Error", "No new feature was added.", level=Qgis.MessageLevel.Warning)
 
     def clear_all_filters(self):
         """Clear filters for all vector layers in the project."""

--- a/arho_feature_template/core/new_plan.py
+++ b/arho_feature_template/core/new_plan.py
@@ -1,7 +1,9 @@
+from typing import TYPE_CHECKING
+
 from qgis.core import QgsProject, QgsVectorLayer
-from qgis.utils import iface
 
 from arho_feature_template.core.update_plan import LandUsePlan, update_selected_plan
+from arho_feature_template.utils.qgis_utils import iface
 
 
 class NewPlan:

--- a/arho_feature_template/core/update_plan.py
+++ b/arho_feature_template/core/update_plan.py
@@ -1,7 +1,10 @@
+from __future__ import annotations
+
 from dataclasses import dataclass
 
 from qgis.core import QgsMapLayer, QgsProject, QgsVectorLayer
-from qgis.utils import iface
+
+from arho_feature_template.utils.qgis_utils import iface
 
 
 # To be extended and moved

--- a/arho_feature_template/core/update_plan.py
+++ b/arho_feature_template/core/update_plan.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from qgis.core import QgsMapLayer, QgsProject, QgsVectorLayer
+from qgis.core import Qgis, QgsMapLayer, QgsProject, QgsVectorLayer
 
-from arho_feature_template.utils.qgis_utils import iface
+from arho_feature_template.utils.qgis_utils import show_message_bar
 
 
 # To be extended and moved
@@ -46,13 +46,15 @@ def set_filter_for_vector_layer(layer_name: str, field_name: str, field_value: s
 
     # Apply the filter to the layer
     if not layer.setSubsetString(expression):
-        iface.messageBar().pushMessage("Error", f"Failed to filter layer {layer_name} with query {expression}", level=3)
+        show_message_bar(
+            "Error", f"Failed to filter layer {layer_name} with query {expression}", level=Qgis.MessageLevel.Critical
+        )
 
 
 def _check_layer_count(layers: list) -> bool:
     """Check if any layers are returned."""
     if not layers:
-        iface.messageBar().pushMessage("Error", "ERROR: No layers found with the specified name.", level=3)
+        show_message_bar("Error", "ERROR: No layers found with the specified name.", level=Qgis.MessageLevel.Critical)
         return False
     return True
 
@@ -60,6 +62,8 @@ def _check_layer_count(layers: list) -> bool:
 def _check_vector_layer(layer: QgsMapLayer) -> bool:
     """Check if the given layer is a vector layer."""
     if not isinstance(layer, QgsVectorLayer):
-        iface.messageBar().pushMessage("Error", f"Layer {layer.name()} is not a vector layer: {type(layer)}", level=3)
+        show_message_bar(
+            "Error", f"Layer {layer.name()} is not a vector layer: {type(layer)}", level=Qgis.MessageLevel.Critical
+        )
         return False
     return True

--- a/arho_feature_template/core/update_plan.py
+++ b/arho_feature_template/core/update_plan.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import cast
 
 from qgis.core import Qgis, QgsMapLayer, QgsProject, QgsVectorLayer
 
+from arho_feature_template.core.exceptions import UnexpectedNoneError
 from arho_feature_template.utils.qgis_utils import show_message_bar
 
 
@@ -24,7 +26,7 @@ LAYER_PLAN_ID_MAP = {
 }
 
 
-def update_selected_plan(new_plan: LandUsePlan):
+def update_selected_plan(new_plan: LandUsePlan) -> None:
     """Update the project layers based on the selected land use plan."""
     plan_id = new_plan.id
 
@@ -33,14 +35,17 @@ def update_selected_plan(new_plan: LandUsePlan):
         set_filter_for_vector_layer(layer_name, field_name, plan_id)
 
 
-def set_filter_for_vector_layer(layer_name: str, field_name: str, field_value: str):
+def set_filter_for_vector_layer(layer_name: str, field_name: str, field_value: str) -> None:
     """Set a filter for the given vector layer."""
-    layers = QgsProject.instance().mapLayersByName(layer_name)
+    project = QgsProject.instance()
+    if project is None:
+        raise UnexpectedNoneError
+    layers = project.mapLayersByName(layer_name)
 
     if not _check_layer_count(layers):
         return
 
-    layer = layers[0]
+    layer = cast(QgsVectorLayer, layers[0])
 
     expression = f"\"{field_name}\" = '{field_value}'"
 

--- a/arho_feature_template/gui/template_dock.py
+++ b/arho_feature_template/gui/template_dock.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from importlib import resources
 from typing import TYPE_CHECKING
 
@@ -13,10 +15,10 @@ DockClass, _ = uic.loadUiType(ui_path)
 
 
 class TemplateLibraryDock(QgsDockWidget, DockClass):  # type: ignore
-    library_selection: "QComboBox"
-    search_box: "QgsFilterLineEdit"
-    template_list: "QListView"
-    txt_tip: "QLabel"
+    library_selection: QComboBox
+    search_box: QgsFilterLineEdit
+    template_list: QListView
+    txt_tip: QLabel
 
     def __init__(self) -> None:
         super().__init__()

--- a/arho_feature_template/gui/template_dock.py
+++ b/arho_feature_template/gui/template_dock.py
@@ -18,7 +18,7 @@ class TemplateLibraryDock(QgsDockWidget, DockClass):  # type: ignore
     template_list: "QListView"
     txt_tip: "QLabel"
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.setupUi(self)
 

--- a/arho_feature_template/plugin.py
+++ b/arho_feature_template/plugin.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
 
 import os
-from typing import TYPE_CHECKING, Callable, cast
+from typing import TYPE_CHECKING, Callable
 
 from qgis.PyQt.QtCore import QCoreApplication, Qt, QTranslator
 from qgis.PyQt.QtGui import QIcon
 from qgis.PyQt.QtWidgets import QAction, QDialog, QMessageBox, QWidget
-from qgis.utils import iface
 
 from arho_feature_template.core.feature_template_library import FeatureTemplater, TemplateGeometryDigitizeMapTool
 from arho_feature_template.core.new_plan import NewPlan
@@ -17,11 +16,10 @@ from arho_feature_template.qgis_plugin_tools.tools.i18n import setup_translation
 from arho_feature_template.qgis_plugin_tools.tools.resources import plugin_name
 from arho_feature_template.utils.db_utils import get_existing_database_connection_names
 from arho_feature_template.utils.misc_utils import PLUGIN_PATH
+from arho_feature_template.utils.qgis_utils import iface
 
 if TYPE_CHECKING:
-    from qgis.gui import QgisInterface, QgsMapTool
-
-    iface: QgisInterface = cast("QgisInterface", iface)  # type: ignore[no-redef]
+    from qgis.gui import QgsMapTool
 
 
 class Plugin:

--- a/arho_feature_template/utils/qgis_utils.py
+++ b/arho_feature_template/utils/qgis_utils.py
@@ -1,0 +1,7 @@
+from typing import cast
+
+from qgis.gui import QgisInterface
+from qgis.utils import iface as qgis_iface
+
+# This is just a workaround to make static typing work
+iface = cast(QgisInterface, qgis_iface)

--- a/arho_feature_template/utils/qgis_utils.py
+++ b/arho_feature_template/utils/qgis_utils.py
@@ -1,7 +1,21 @@
-from typing import cast
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, cast
 
 from qgis.gui import QgisInterface
 from qgis.utils import iface as qgis_iface
 
+from arho_feature_template.core.exceptions import UnexpectedNoneError
+
+if TYPE_CHECKING:
+    from qgis.core import Qgis
+
 # This is just a workaround to make static typing work
 iface = cast(QgisInterface, qgis_iface)
+
+
+def show_message_bar(title: str, message: str, level: Qgis.MessageLevel) -> None:
+    message_bar = iface.messageBar()
+    if message_bar is None:
+        raise UnexpectedNoneError
+    message_bar.pushMessage(title, message, level=level)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "arho-feature-template"
 version = "0.1.0"
-requires-python = ">= 3.8"
+requires-python = ">= 3.9"
 
 [tool.setuptools]
 packages = ["arho_feature_template"]
@@ -18,7 +18,7 @@ testpaths = "tests"
 omit = ["arho_feature_template/qgis_plugin_tools/*"]
 
 [tool.ruff]
-target-version = "py38"
+target-version = "py39"
 extend = "ruff_defaults.toml"
 exclude = ["arho_feature_template/qgis_plugin_tools"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ omit = ["arho_feature_template/qgis_plugin_tools/*"]
 [tool.ruff]
 target-version = "py39"
 extend = "ruff_defaults.toml"
-exclude = ["arho_feature_template/qgis_plugin_tools"]
+exclude = ["arho_feature_template/qgis_plugin_tools", "create_qgis_venv.py"]
 
 [tool.ruff.lint]
 unfixable = [
@@ -28,8 +28,24 @@ unfixable = [
     "F841", # unused variables
 ]
 
+
+[tool.mypy]
+python_version = "3.9"
+disallow_untyped_defs = true
+disallow_any_unimported = true
+no_implicit_optional = true
+check_untyped_defs = true
+warn_return_any = true
+show_error_codes = true
+warn_unused_ignores = true
+warn_unreachable = true
+
 [[tool.mypy.overrides]]
 module = "arho_feature_template.qgis_plugin_tools.*"
+ignore_errors = true
+
+[[tool.mypy.overrides]]
+module = "create_qgis_venv"
 ignore_errors = true
 
 [[tool.mypy.overrides]]

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,5 +1,5 @@
 from arho_feature_template.qgis_plugin_tools.tools.resources import plugin_name
 
 
-def test_plugin_name():
+def test_plugin_name() -> None:
     assert plugin_name() == "ARHOfeaturetemplate"


### PR DESCRIPTION
`qgis` python-paketin kansioon (`C:\OSGeo4W\apps\qgis-ltr\python\qgis`) pitää lisätä `py.typed` tiedosto, jotta mypy tarkistaa tyypitykset oikein.

QGIS sanoo, että esim. `iface.mapCanvas()` on Optional, eli voi olla myös `None`, jolloin mypy antaa virheitä `Item "None" of "Optional[QgsMapCanvas]" has no attribute "mapToolSet"Mypy[union-attr]`. Nyt lisäsin tarkastukset aina vastaaville tyyliin:
```python
canvas = iface.mapCanvas()
if canvas is None:
    raise UnexpectedNoneError
canvas.mapToolSet.connect(self.templater.digitize_map_tool.deactivate)
```
Riittäisikö, jos vaan luottaisi, että canvas on aina olemassa ja lisäisi vain ignoren:
```python
canvas.mapToolSet.connect(self.templater.digitize_map_tool.deactivate)  # type: ignore[union-attr]
```