### PR TITLE
Muokkauksia kaavakohdetemplaattien lomakkeeseen

### DIFF
--- a/arho_feature_template/gui/template_attribute_form.py
+++ b/arho_feature_template/gui/template_attribute_form.py
@@ -3,23 +3,23 @@ from __future__ import annotations
 from importlib import resources
 from typing import TYPE_CHECKING
 
-from qgis.core import QgsApplication, QgsFeature
 from qgis.gui import QgsSpinBox
 from qgis.PyQt import uic
 from qgis.PyQt.QtWidgets import (
     QDialog,
     QDialogButtonBox,
     QLineEdit,
-    QPushButton,
     QScrollArea,
     QSizePolicy,
     QSpacerItem,
     QTreeWidget,
+    QTreeWidgetItem,
 )
 
 from arho_feature_template.gui.plan_regulation_group_widget import PlanRegulationGroupWidget
 
 if TYPE_CHECKING:
+    from qgis.core import QgsFeature
     from qgis.PyQt.QtWidgets import QWidget
 
     from arho_feature_template.core.template_library_config import Feature, FeatureTemplate
@@ -39,64 +39,60 @@ class TemplateAttributeForm(QDialog, FormClass):  # type: ignore
         self.feature_name: QLineEdit
         self.feature_description: QLineEdit
         self.feature_underground: QLineEdit
-        self.feature_vertical_boundaries: QLineEdit
         self.plan_regulation_group_scrollarea: QScrollArea
         self.plan_regulation_group_scrollarea_contents: QWidget
         self.plan_regulation_groups_tree: QTreeWidget
-        self.add_plan_regulation_group_btn: QPushButton
         self.button_box: QDialogButtonBox
 
         # SIGNALS
         self.button_box.accepted.connect(self._on_ok_clicked)
-        self.add_plan_regulation_group_btn.clicked.connect(self._on_add_plan_regulation_group_clicked)
+        self.plan_regulation_groups_tree.itemDoubleClicked.connect(self.add_selected_plan_regulation_group)
 
         # INIT
         self.attribute_widgets = {
             "name": self.feature_name,
             "description": self.feature_description,
             "type_of_underground_id": self.feature_underground,
-            # self.feature_vertical_boundaries
         }
+        # TODO: The 'configs' could be a mapping where keys are plan regulation group names and
+        # values are the related configurations
+        self.configs: dict[str, Feature] = {}
         self.scroll_area_spacer = None
         self.available_plan_regulation_group_configs: list[Feature] = []
-        self.add_plan_regulation_group_btn.setIcon(QgsApplication.getThemeIcon("mActionAdd.svg"))
 
         self.setWindowTitle(feature_template_config.name)
         self.init_feature_attributes_from_template(feature_template_config)
         self.init_plan_regulation_groups_from_template(feature_template_config)
         self.init_plan_regulation_group_library()
 
-    def add_spacer(self):
+    def _add_spacer(self):
         self.scroll_area_spacer = QSpacerItem(0, 0, QSizePolicy.Expanding, QSizePolicy.Expanding)
         self.plan_regulation_group_scrollarea_contents.layout().addItem(self.scroll_area_spacer)
 
-    def remove_spacer(self):
+    def _remove_spacer(self):
         if self.scroll_area_spacer is not None:
             self.plan_regulation_group_scrollarea_contents.layout().removeItem(self.scroll_area_spacer)
             self.scroll_area_spacer = None
 
+    def add_selected_plan_regulation_group(self, item: QTreeWidgetItem, column: int):
+        if not item.parent():
+            return
+        config = self.configs.get(item.text(column))
+        if not config:
+            print(f"Could not find plan regulation group configuration for {item.text(column)}")  # noqa: T201
+            return
+        self.add_plan_regulation_group(config)
+
     def add_plan_regulation_group(self, feature_config: Feature):
         new_plan_regulation_group = PlanRegulationGroupWidget(feature_config)
         new_plan_regulation_group.delete_signal.connect(self.remove_plan_regulation_group)
-        self.remove_spacer()
+        self._remove_spacer()
         self.plan_regulation_group_scrollarea_contents.layout().addWidget(new_plan_regulation_group)
-        self.add_spacer()
+        self._add_spacer()
 
     def remove_plan_regulation_group(self, plan_regulation_group_widget: PlanRegulationGroupWidget):
         self.plan_regulation_group_scrollarea_contents.layout().removeWidget(plan_regulation_group_widget)
         plan_regulation_group_widget.deleteLater()
-
-    def _on_add_plan_regulation_group_clicked(self):
-        selected = self.plan_regulation_groups_tree.selectedItems()
-        if len(selected) == 0:
-            # Nothing selected
-            return
-        if len(selected) > 1:
-            # Too many selected, but should allow selecting only 1 item at a time
-            return
-        selected_plan_regulation_group = selected[0]
-        print(f"Trying to add plan regulation group {selected_plan_regulation_group.text(0)}")  # noqa: T201
-        # self.add_plan_regulation_group()  # TODO: Implement
 
     def init_plan_regulation_group_library(self):
         # Now plan regulation group tree widget/view is just static placeholder for demo

--- a/arho_feature_template/gui/template_attribute_form.ui
+++ b/arho_feature_template/gui/template_attribute_form.ui
@@ -15,299 +15,273 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_4">
    <item>
-    <layout class="QFormLayout" name="feature_details_layout">
-     <item row="0" column="0">
-      <widget class="QLabel" name="feature_name_label">
-       <property name="text">
-        <string>Kohteen nimi</string>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="1">
-      <widget class="QLineEdit" name="feature_name"/>
-     </item>
-     <item row="1" column="0">
-      <widget class="QLabel" name="feature_description_label">
-       <property name="text">
-        <string>Kohteen kuvaus</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="1">
-      <widget class="QLineEdit" name="feature_description"/>
-     </item>
-     <item row="2" column="0">
-      <widget class="QLabel" name="feature_underground_label">
-       <property name="text">
-        <string>Maanalaisuus</string>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="0">
-      <widget class="QLabel" name="feature_vertical_boundaries_label">
-       <property name="text">
-        <string>Pystysuuntainen rajaus</string>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="1">
-      <widget class="QLineEdit" name="feature_vertical_boundaries"/>
-     </item>
-     <item row="2" column="1">
-      <widget class="QSpinBox" name="feature_underground"/>
-     </item>
-    </layout>
-   </item>
-   <item>
-    <spacer name="feature_details_spacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
+    <widget class="QTabWidget" name="tabs">
+     <property name="currentIndex">
+      <number>0</number>
      </property>
-     <property name="sizeType">
-      <enum>QSizePolicy::Preferred</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>10</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item>
-    <widget class="Line" name="horizontal_divider">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
+     <widget class="QWidget" name="feature_tab">
+      <attribute name="title">
+       <string>Kaavakohteen tiedot</string>
+      </attribute>
+      <layout class="QFormLayout" name="formLayout">
+       <item row="0" column="0">
+        <widget class="QLabel" name="feature_name_label">
+         <property name="text">
+          <string>Kaavakohteen nimi</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="QLineEdit" name="feature_name"/>
+       </item>
+       <item row="1" column="0">
+        <widget class="QLabel" name="feature_description_label">
+         <property name="text">
+          <string>Kaavakohteen kuvaus</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <widget class="QTextEdit" name="feature_description">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="0">
+        <widget class="QLabel" name="feature_underground_label">
+         <property name="text">
+          <string>Maanalaisuus</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="1">
+        <widget class="QComboBox" name="feature_underground"/>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="plan_regulation_groups_tab">
+      <attribute name="title">
+       <string>Kaavamääräysryhmät</string>
+      </attribute>
+      <layout class="QHBoxLayout" name="horizontalLayout_2">
+       <item>
+        <layout class="QVBoxLayout" name="verticalLayout_3">
+         <item>
+          <widget class="QLabel" name="label_2">
+           <property name="text">
+            <string>Kaavamääräysryhmäkirjastot</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QComboBox" name="comboBox">
+           <item>
+            <property name="text">
+             <string>Katja</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>Omat</string>
+            </property>
+           </item>
+          </widget>
+         </item>
+         <item>
+          <widget class="QgsFilterLineEdit" name="mLineEdit">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="placeholderText">
+            <string>Suodata kaavamääräysryhmiä</string>
+           </property>
+           <property name="clearButtonEnabled">
+            <bool>true</bool>
+           </property>
+           <property name="showSearchIcon">
+            <bool>true</bool>
+           </property>
+           <property name="qgisRelation" stdset="0">
+            <string notr="true"/>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QTreeWidget" name="plan_regulation_groups_tree">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Maximum" vsizetype="Expanding">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="frameShape">
+            <enum>QFrame::StyledPanel</enum>
+           </property>
+           <property name="frameShadow">
+            <enum>QFrame::Sunken</enum>
+           </property>
+           <property name="editTriggers">
+            <set>QAbstractItemView::NoEditTriggers</set>
+           </property>
+           <property name="dragDropMode">
+            <enum>QAbstractItemView::NoDragDrop</enum>
+           </property>
+           <property name="alternatingRowColors">
+            <bool>false</bool>
+           </property>
+           <attribute name="headerVisible">
+            <bool>false</bool>
+           </attribute>
+           <column>
+            <property name="text">
+             <string>1</string>
+            </property>
+           </column>
+           <item>
+            <property name="text">
+             <string>Aluevaraukset</string>
+            </property>
+            <item>
+             <property name="text">
+              <string>Asuinrakennusten alue</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Asuinkerrostalojen alue</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Asuinpientalojen alue</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Rivitalojen ja muiden kytkettyjen asuinrakennusten alue</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Erillispientalojen alue</string>
+             </property>
+            </item>
+           </item>
+           <item>
+            <property name="text">
+             <string>Rakennusalat</string>
+            </property>
+            <item>
+             <property name="text">
+              <string>Kunnan tai kaupunginosas raja</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Korttelialue tai korttelialueen osa</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Sitovan tonttijaon mukainen tontti</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Ohjeellinen tontti / rakennusala</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Rakennusala</string>
+             </property>
+            </item>
+           </item>
+           <item>
+            <property name="text">
+             <string>Numeeriset ja tekstimuotoiset määräykset</string>
+            </property>
+            <item>
+             <property name="text">
+              <string>Kaupungin- tai kunnanosan numero</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Kaupungin- tai kunnanosan nimi</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Korttelin numero</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Tontin tai rakennuspaikan numero</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Ohjeellisen tontin tai rakennuspaikan numero</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Kadun tai tien nimi</string>
+             </property>
+            </item>
+           </item>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QVBoxLayout" name="verticalLayout">
+         <item>
+          <widget class="QLabel" name="label">
+           <property name="text">
+            <string>Kaavamääräysryhmät</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QScrollArea" name="plan_regulation_group_scrollarea">
+           <property name="widgetResizable">
+            <bool>true</bool>
+           </property>
+           <widget class="QWidget" name="plan_regulation_group_scrollarea_contents">
+            <property name="geometry">
+             <rect>
+              <x>0</x>
+              <y>0</y>
+              <width>449</width>
+              <height>624</height>
+             </rect>
+            </property>
+            <layout class="QVBoxLayout" name="verticalLayout_2"/>
+           </widget>
+          </widget>
+         </item>
+        </layout>
+       </item>
+      </layout>
+     </widget>
     </widget>
    </item>
    <item>
-    <spacer name="plan_regulation_group_spacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
+    <widget class="QDialogButtonBox" name="button_box">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
      </property>
-     <property name="sizeType">
-      <enum>QSizePolicy::Preferred</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>10</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_2">
-     <item>
-      <layout class="QVBoxLayout" name="verticalLayout_3">
-       <item>
-        <widget class="QLabel" name="label_2">
-         <property name="text">
-          <string>Lisää kaavamääräysryhmä</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QgsFilterLineEdit" name="mLineEdit">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="placeholderText">
-          <string>Suodata kaavamääräysryhmiä</string>
-         </property>
-         <property name="clearButtonEnabled">
-          <bool>true</bool>
-         </property>
-         <property name="showSearchIcon">
-          <bool>true</bool>
-         </property>
-         <property name="qgisRelation" stdset="0">
-          <string notr="true"/>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QTreeWidget" name="plan_regulation_groups_tree">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Expanding">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="frameShape">
-          <enum>QFrame::StyledPanel</enum>
-         </property>
-         <property name="frameShadow">
-          <enum>QFrame::Sunken</enum>
-         </property>
-         <property name="editTriggers">
-          <set>QAbstractItemView::NoEditTriggers</set>
-         </property>
-         <property name="dragDropMode">
-          <enum>QAbstractItemView::NoDragDrop</enum>
-         </property>
-         <property name="alternatingRowColors">
-          <bool>false</bool>
-         </property>
-         <attribute name="headerVisible">
-          <bool>false</bool>
-         </attribute>
-         <column>
-          <property name="text">
-           <string>1</string>
-          </property>
-         </column>
-         <item>
-          <property name="text">
-           <string>Aluevaraukset</string>
-          </property>
-          <item>
-           <property name="text">
-            <string>Asuinrakennusten alue</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Asuinkerrostalojen alue</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Asuinpientalojen alue</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Rivitalojen ja muiden kytkettyjen asuinrakennusten alue</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Erillispientalojen alue</string>
-           </property>
-          </item>
-         </item>
-         <item>
-          <property name="text">
-           <string>Rakennusalat</string>
-          </property>
-          <item>
-           <property name="text">
-            <string>Kunnan tai kaupunginosas raja</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Korttelialue tai korttelialueen osa</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Sitovan tonttijaon mukainen tontti</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Ohjeellinen tontti / rakennusala</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Rakennusala</string>
-           </property>
-          </item>
-         </item>
-         <item>
-          <property name="text">
-           <string>Numeeriset ja tekstimuotoiset määräykset</string>
-          </property>
-          <item>
-           <property name="text">
-            <string>Kaupungin- tai kunnanosan numero</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Kaupungin- tai kunnanosan nimi</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Korttelin numero</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Tontin tai rakennuspaikan numero</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Ohjeellisen tontin tai rakennuspaikan numero</string>
-           </property>
-          </item>
-          <item>
-           <property name="text">
-            <string>Kadun tai tien nimi</string>
-           </property>
-          </item>
-         </item>
-        </widget>
-       </item>
-       <item>
-        <widget class="QPushButton" name="add_plan_regulation_group_btn">
-         <property name="text">
-          <string>Lisää kaavamääräysryhmä</string>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </item>
-     <item>
-      <layout class="QVBoxLayout" name="verticalLayout">
-       <item>
-        <widget class="QLabel" name="label">
-         <property name="text">
-          <string>Kaavamääräykset</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QScrollArea" name="plan_regulation_group_scrollarea">
-         <property name="widgetResizable">
-          <bool>true</bool>
-         </property>
-         <widget class="QWidget" name="plan_regulation_group_scrollarea_contents">
-          <property name="geometry">
-           <rect>
-            <x>0</x>
-            <y>0</y>
-            <width>469</width>
-            <height>501</height>
-           </rect>
-          </property>
-          <layout class="QVBoxLayout" name="verticalLayout_2"/>
-         </widget>
-        </widget>
-       </item>
-      </layout>
-     </item>
-    </layout>
-   </item>
-   <item>
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
-      <widget class="QDialogButtonBox" name="button_box">
-       <property name="standardButtons">
-        <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
-       </property>
-      </widget>
-     </item>
-    </layout>
+    </widget>
    </item>
   </layout>
  </widget>


### PR DESCRIPTION
- Poista Lisää kaavamääräysryhmä -nappi
- Tuplaklikkaamalla kaavamääräysryhmää kirjastossa, ryhmä lisätään kaavakohteelle
- Muokkaa otsikointeja ("Lisää kaavamääräysryhmä" -> "Kaavamääräysryhmäkirjastot", "Kaavamääräykset" -> "Kaavamääräysryhmät")
- Muokkaa käyttöliittymää niin, että eri osiot tabeissa
  - Ensimmäinen tabi "Kaavakohteen tiedot" tai "Perustiedot"
  - Seuraava "Kaavamääräysryhmät"