### PR TITLE
Kaavamääräysryhmän lomakkeen otsikon dynaaminen nimeäminen

### DIFF
--- a/arho_feature_template/core/plan_manager.py
+++ b/arho_feature_template/core/plan_manager.py
@@ -168,12 +168,6 @@ class PlanManager:
     def _open_regulation_group_form(self, regulation_group: RegulationGroup):
         regulation_group_form = PlanRegulationGroupForm(regulation_group, self.active_plan_regulation_group_library)
 
-        # Dynamically rename form title.
-        if regulation_group == RegulationGroup():
-            regulation_group_form.setWindowTitle("Luo kaavamääräysryhmä")
-        else:
-            regulation_group_form.setWindowTitle("Muokkaa kaavamääräysryhmää")
-
         if regulation_group_form.exec_():
             if regulation_group_form.save_as_config:
                 save_regulation_group_as_config(regulation_group_form.model)

--- a/arho_feature_template/core/plan_manager.py
+++ b/arho_feature_template/core/plan_manager.py
@@ -167,6 +167,13 @@ class PlanManager:
 
     def _open_regulation_group_form(self, regulation_group: RegulationGroup):
         regulation_group_form = PlanRegulationGroupForm(regulation_group, self.active_plan_regulation_group_library)
+
+        # Dynamically rename form title.
+        if regulation_group == RegulationGroup():
+            regulation_group_form.setWindowTitle("Luo kaavamääräysryhmä")
+        else:
+            regulation_group_form.setWindowTitle("Muokkaa kaavamääräysryhmää")
+
         if regulation_group_form.exec_():
             if regulation_group_form.save_as_config:
                 save_regulation_group_as_config(regulation_group_form.model)

--- a/arho_feature_template/gui/dialogs/plan_regulation_group_form.py
+++ b/arho_feature_template/gui/dialogs/plan_regulation_group_form.py
@@ -135,6 +135,7 @@ class PlanRegulationGroupForm(QDialog, FormClass):  # type: ignore
             layout.addWidget(self.link_label_text)
 
             self.regulation_group_info_tab.layout().insertLayout(1, layout)
+            self.setWindowTitle("Muokkaa kaavamääräysryhmää")
 
     def _initalize_regulation_from_config(self, config: RegulationConfig, parent: QTreeWidgetItem | None = None):
         item = self.regulations_selection_widget.add_item_to_tree(config.name, config, parent)


### PR DESCRIPTION
Dynaamisesti vaihtaa kaavamääräysryhmän lomakkeen otsikon riippuen luodaanko uutta vai editoidaanko olemassaolevaa.