### PR TITLE
Vapaaehtoisten tekstien tallennuksen korjaus

### DIFF
--- a/arho_feature_template/core/models.py
+++ b/arho_feature_template/core/models.py
@@ -12,7 +12,7 @@ import yaml
 from arho_feature_template.exceptions import ConfigSyntaxError
 from arho_feature_template.project.layers.code_layers import AdditionalInformationTypeLayer, UndergroundTypeLayer
 from arho_feature_template.qgis_plugin_tools.tools.resources import resources_path
-from arho_feature_template.utils.misc_utils import LANGUAGE, get_layer_by_name, iface
+from arho_feature_template.utils.misc_utils import deserialize_localized_text, get_layer_by_name, iface
 
 if TYPE_CHECKING:
     from datetime import datetime
@@ -246,8 +246,8 @@ class RegulationConfig:
 
     id: str
     regulation_code: str
-    name: str
-    description: str
+    name: str | None
+    description: str | None
     status: str
     level: int
     parent_id: str | None
@@ -268,8 +268,8 @@ class RegulationConfig:
         return cls(
             id=feature["id"],
             regulation_code=feature["value"],
-            name=feature["name"].get(LANGUAGE) if feature["name"] else None,
-            description=feature["description"].get(LANGUAGE) if feature["description"] else None,
+            name=deserialize_localized_text(feature["name"]),
+            description=deserialize_localized_text(feature["description"]),
             status=feature["status"],
             level=feature["level"],
             parent_id=feature["parent_id"],
@@ -287,8 +287,8 @@ class AdditionalInformationConfig:
     # From layer
     id: str
     additional_information_type: str
-    name: str
-    description: str
+    name: str | None
+    description: str | None
     status: str
     level: int
     parent_id: str | None
@@ -344,8 +344,8 @@ class AdditionalInformationConfigLibrary:
             ai_config = AdditionalInformationConfig(
                 id=feature["id"],
                 additional_information_type=ai_code,
-                name=feature["name"].get(LANGUAGE) if feature["name"] else None,
-                description=feature["description"].get(LANGUAGE) if feature["description"] else None,
+                name=deserialize_localized_text(feature["name"]),
+                description=deserialize_localized_text(feature["description"]),
                 status=feature["status"],
                 level=feature["level"],
                 parent_id=feature["parent_id"],

--- a/arho_feature_template/gui/components/plan_regulation_widget.py
+++ b/arho_feature_template/gui/components/plan_regulation_widget.py
@@ -118,6 +118,8 @@ class RegulationWidget(QWidget, FormClass):  # type: ignore
 
             for child_code in top_level_config.children:
                 config = ai_config_library.get_config_by_code(child_code)
+                if not config.name:
+                    continue
                 _add_action(top_level_code, config.additional_information_type, config.name)
 
         # Create main menu for btn and add submenus

--- a/arho_feature_template/gui/docks/new_feature_dock.py
+++ b/arho_feature_template/gui/docks/new_feature_dock.py
@@ -21,18 +21,17 @@ DockClass, _ = uic.loadUiType(ui_path)
 
 
 class NewFeatureDock(QgsDockWidget, DockClass):  # type: ignore
+    library_selection: QComboBox
+    search_box: QgsFilterLineEdit
+    template_list: QListWidget
+    txt_tip: QLabel
+    dockWidgetContents: QWidget  # noqa: N815
+
     tool_activated = pyqtSignal()
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.setupUi(self)
-
-        # TYPES
-        self.library_selection: QComboBox
-        self.search_box: QgsFilterLineEdit
-        self.template_list: QListWidget
-        self.txt_tip: QLabel
-        self.dockWidgetContents: QWidget
 
         # INIT
         # 1. New feature grid
@@ -66,7 +65,7 @@ class NewFeatureDock(QgsDockWidget, DockClass):  # type: ignore
         if self.active_feature_type:
             self.tool_activated.emit()
 
-    def filter_plan_feature_templates(self):
+    def filter_plan_feature_templates(self) -> None:
         # Consider both search text and active plan feature type
         search_text = self.search_box.value().lower()
 

--- a/arho_feature_template/gui/docks/regulation_groups_dock.py
+++ b/arho_feature_template/gui/docks/regulation_groups_dock.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from importlib import resources
 from typing import TYPE_CHECKING
 
@@ -20,6 +22,14 @@ DockClass, _ = uic.loadUiType(ui_path)
 
 
 class RegulationGroupsDock(QgsDockWidget, DockClass):  # type: ignore
+    search_box: QgsFilterLineEdit
+    regulation_group_list: QListWidget
+    dockWidgetContents: QWidget  # noqa: N815
+
+    new_btn: QPushButton
+    delete_btn: QPushButton
+    edit_btn: QPushButton
+
     new_regulation_group_requested = pyqtSignal()
     edit_regulation_group_requested = pyqtSignal(RegulationGroup)
     delete_regulation_group_requested = pyqtSignal(RegulationGroup)
@@ -27,15 +37,6 @@ class RegulationGroupsDock(QgsDockWidget, DockClass):  # type: ignore
     def __init__(self):
         super().__init__()
         self.setupUi(self)
-
-        # TYPES
-        self.search_box: QgsFilterLineEdit
-        self.regulation_group_list: QListWidget
-        self.dockWidgetContents: QWidget
-
-        self.new_btn: QPushButton
-        self.delete_btn: QPushButton
-        self.edit_btn: QPushButton
 
         self.new_btn.setIcon(QgsApplication.getThemeIcon("mActionAdd.svg"))
         self.delete_btn.setIcon(QgsApplication.getThemeIcon("mActionDeleteSelected.svg"))
@@ -115,7 +116,7 @@ class RegulationGroupsDock(QgsDockWidget, DockClass):  # type: ignore
             if response == QMessageBox.Yes:
                 self.delete_regulation_group_requested.emit(self.selected_group)
 
-    def filter_regulation_groups(self):
+    def filter_regulation_groups(self) -> None:
         search_text = self.search_box.value().lower()
 
         for index in range(self.regulation_group_list.count()):

--- a/arho_feature_template/utils/misc_utils.py
+++ b/arho_feature_template/utils/misc_utils.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import os
 from contextlib import suppress
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from qgis.core import QgsExpressionContextUtils, QgsProject, QgsVectorLayer
 from qgis.PyQt.QtCore import QSettings, pyqtBoundSignal
@@ -113,3 +113,18 @@ def disconnect_signal(signal: pyqtBoundSignal) -> None:
     """
     with suppress(TypeError):
         signal.disconnect()
+
+
+def serialize_localized_text(text: str | None) -> dict[str, str] | None:
+    if isinstance(text, str):
+        text = text.strip()
+    if text:
+        return {LANGUAGE: text}
+    return None
+
+
+def deserialize_localized_text(text_value: dict[str, str] | None | Any) -> str | None:
+    text = None
+    if isinstance(text_value, dict):
+        text = text_value.get(LANGUAGE)
+    return text


### PR DESCRIPTION
Aiemmin, jos pluginissa kentän jätti tyhjäksi, kantaan tallentui `{"fin": null}`, joka meni myös Ryhtiin. Ryhti olettaa, että koko tekstiarvo on `null`, jos tekstiä ei annettu.