### PR TITLE
Dock widgettien napit eivät jää enää pohjaan

### DIFF
--- a/arho_feature_template/core/plan_manager.py
+++ b/arho_feature_template/core/plan_manager.py
@@ -95,12 +95,12 @@ class PlanManager:
         self.regulation_group_libraries = []
 
         # Initialize new feature dock
-        self.new_feature_dock = NewFeatureDock()
+        self.new_feature_dock = NewFeatureDock(iface.mainWindow())
         self.new_feature_dock.tool_activated.connect(self.add_new_plan_feature)
         self.new_feature_dock.hide()
 
         # Initialize regulation groups dock
-        self.regulation_groups_dock = RegulationGroupsDock()
+        self.regulation_groups_dock = RegulationGroupsDock(iface.mainWindow())
         self.regulation_groups_dock.new_regulation_group_requested.connect(self.create_new_regulation_group)
         self.regulation_groups_dock.edit_regulation_group_requested.connect(self.edit_regulation_group)
         self.regulation_groups_dock.delete_regulation_group_requested.connect(self.delete_regulation_group)

--- a/arho_feature_template/gui/docks/new_feature_dock.py
+++ b/arho_feature_template/gui/docks/new_feature_dock.py
@@ -29,8 +29,8 @@ class NewFeatureDock(QgsDockWidget, DockClass):  # type: ignore
 
     tool_activated = pyqtSignal()
 
-    def __init__(self) -> None:
-        super().__init__()
+    def __init__(self, parent=None) -> None:
+        super().__init__(parent)
         self.setupUi(self)
 
         # INIT

--- a/arho_feature_template/gui/docks/regulation_groups_dock.py
+++ b/arho_feature_template/gui/docks/regulation_groups_dock.py
@@ -34,8 +34,8 @@ class RegulationGroupsDock(QgsDockWidget, DockClass):  # type: ignore
     edit_regulation_group_requested = pyqtSignal(RegulationGroup)
     delete_regulation_group_requested = pyqtSignal(RegulationGroup)
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, parent=None):
+        super().__init__(parent)
         self.setupUi(self)
 
         self.new_btn.setIcon(QgsApplication.getThemeIcon("mActionAdd.svg"))


### PR DESCRIPTION
Muutenkin nappien logiikka hieman muuttunut jos käyttäjä on laittanut dockinsa tabeiksi. Klikkaamalla päällimäisen dock widgetin nappia dock widget suljetaan. Jos taas käyttäjä klikkaa alla olevan, mutta avonaisen dock widgetin nappia, widget tuodaan päällimmäiseksi. Jos käyttäjä painaa avaamattoman dock widgetin nappia, widget avataan ja tuodaan tabeista päällimmäisimmäksi.