### PR TITLE
Korjaa aktiiviseen kaavakohteeseen zoomas

### DIFF
--- a/arho_feature_template/core/plan_manager.py
+++ b/arho_feature_template/core/plan_manager.py
@@ -60,7 +60,6 @@ from arho_feature_template.utils.misc_utils import (
     iface,
     set_active_plan_id,
     use_wait_cursor,
-    zoom_to_layer,
 )
 
 if TYPE_CHECKING:
@@ -387,7 +386,16 @@ class PlanManager(QObject):
 
             self.set_permanent_identifier(identifier)
 
-            zoom_to_layer(plan_layer)
+            self.zoom_to_active_plan()
+
+    def zoom_to_active_plan(self):
+        """Zoom to the active plan layer."""
+        active_plan_feature = next(PlanLayer.get_features(), None)
+        if active_plan_feature:
+            bounding_box = active_plan_feature.geometry().boundingBox()
+            canvas = iface.mapCanvas()
+            canvas.zoomToFeatureExtent(bounding_box.buffered(50))
+            canvas.refresh()
 
     def load_land_use_plan(self):
         """Load an existing land use plan using a dialog selection."""

--- a/arho_feature_template/utils/misc_utils.py
+++ b/arho_feature_template/utils/misc_utils.py
@@ -138,9 +138,3 @@ def use_wait_cursor(func):
             return func(*args, **kwargs)
 
     return wrapper
-
-
-def zoom_to_layer(layer: QgsVectorLayer):
-    canvas = iface.mapCanvas()
-    canvas.setExtent(layer.extent())
-    canvas.refresh()


### PR DESCRIPTION
Zooming to layer failed probably because QGIS is
caching and estimating layer extent.