### PR TITLE
Käytä samankokoisia marginaaleja Luo kaavakohde -paneelissa kuin muissa paneeleissa

### DIFF
--- a/arho_feature_template/gui/docks/new_feature_dock.py
+++ b/arho_feature_template/gui/docks/new_feature_dock.py
@@ -13,7 +13,7 @@ from arho_feature_template.project.layers.plan_layers import PlanLayer
 
 if TYPE_CHECKING:
     from qgis.gui import QgsFilterLineEdit
-    from qgis.PyQt.QtWidgets import QComboBox, QLabel, QWidget
+    from qgis.PyQt.QtWidgets import QComboBox, QWidget
 
     from arho_feature_template.core.models import FeatureTemplateLibrary, PlanFeature
 
@@ -25,7 +25,6 @@ class NewFeatureDock(QgsDockWidget, DockClass):  # type: ignore
     library_selection: QComboBox
     search_box: QgsFilterLineEdit
     template_list: QListWidget
-    txt_tip: QLabel
     dockWidgetContents: QWidget  # noqa: N815
 
     tool_activated = pyqtSignal()

--- a/arho_feature_template/gui/docks/new_feature_dock.ui
+++ b/arho_feature_template/gui/docks/new_feature_dock.ui
@@ -19,19 +19,19 @@
   <widget class="QWidget" name="dockWidgetContents">
    <layout class="QVBoxLayout" name="verticalLayout">
     <property name="spacing">
-     <number>0</number>
+     <number>6</number>
     </property>
     <property name="leftMargin">
-     <number>0</number>
+     <number>9</number>
     </property>
     <property name="topMargin">
-     <number>0</number>
+     <number>9</number>
     </property>
     <property name="rightMargin">
-     <number>0</number>
+     <number>9</number>
     </property>
     <property name="bottomMargin">
-     <number>0</number>
+     <number>9</number>
     </property>
     <item>
      <widget class="QLabel" name="label">
@@ -102,13 +102,6 @@
     </item>
     <item>
      <widget class="QListWidget" name="template_list"/>
-    </item>
-    <item>
-     <widget class="QLabel" name="txt_tip">
-      <property name="text">
-       <string/>
-      </property>
-     </widget>
     </item>
    </layout>
   </widget>


### PR DESCRIPTION
Paneeli näytti hassulta muiden rinnalla, erityisesti kun paneelin telakoi QGISin ikkunan vasemmalle puolelle.